### PR TITLE
Add SASS_PATH=./node_modules to `styleguide:build` task

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lint:fix": "npm run lint --fix",
     "format": "prettier --write '{src,test}/**/*.{js,jsx,ts,tsx}' && npm run lint:fix",
     "styleguide": "styleguidist server",
-    "styleguide:build": "styleguidist build",
+    "styleguide:build": "SASS_PATH=./node_modules styleguidist build",
     "ts:prod": "tsc --emitDeclarationOnly",
     "ts:check": "tsc --noEmit",
     "webpack:dev": "SASS_PATH=./node_modules webpack --env.dev",


### PR DESCRIPTION
Make sure `SASS_PATH` is set before running `npm build styleguide:build`

The other build tasks are okay because they call subtasks that already do this (e.g. `webpack:dev` and `webpack:prod`)